### PR TITLE
add name to snapshot

### DIFF
--- a/core_tools/drivers/hardware/hardware.py
+++ b/core_tools/drivers/hardware/hardware.py
@@ -131,6 +131,7 @@ class hardware(qc.Instrument):
         if hardware.instanciated == False: # this should happen in the station
             super().__init__(name)
         hardware.instanciated = True
+        self._name = name
     
     @property
     def dac_gate_map(self):
@@ -157,7 +158,8 @@ class hardware(qc.Instrument):
 
         return {'awg2dac_ratios': self.awg2dac_ratios._ratios,
                  'dac_gate_map': self.dac_gate_map,
-                 'virtual_gates': vg_snap                     }
+                 'virtual_gates': vg_snap,
+                 'name': self._name }
 
 if __name__ == '__main__':
     from core_tools.data.SQL.connect import set_up_local_storage, set_up_remote_storage, set_up_local_and_remote_storage


### PR DESCRIPTION
The `hardware` object emulates a qcodes Instrument, but does not add a `name` to the snapshot, breaking some tools using the `qcodes` interface. This PR adds the `name` field to the snapshot.

@sldesnoo-Delft 

Note: even better would be to make hw a real singleton class or instread if creating a new object each time, just find the references with `qcodes.find_or_create_instrument(...)`