### PR TITLE
[RFC] Fix for incorrect index in 2d  videomode

### DIFF
--- a/core_tools/GUI/keysight_videomaps/plotter/plotting_functions.py
+++ b/core_tools/GUI/keysight_videomaps/plotter/plotting_functions.py
@@ -293,7 +293,7 @@ class _2D_live_plot(live_plot):
             irow = i // n_col
             self.top_layout.addWidget(plot_2D, irow, icol, 1, 1)
 
-            range1 = self.parameter_getter.setpoints[0][1][0][-1]
+            range1 = self.parameter_getter.setpoints[0][1][-1]
             range0 = self.parameter_getter.setpoints[0][0][-1]
             img.translate(-range1, -range0)
             img.scale(1/self.shape[0]*range1*2, 1/self.shape[1]*range0*2)


### PR DESCRIPTION
@sldesnoo-Delft The two setpoints for the two axis should be defined in the same way, so extracting the latest datapoint should happen in a similar way.