### PR TITLE
Removed parentheses from QTextEdit type hint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,6 +112,10 @@ venv.bak/
 .spyderproject
 .spyproject
 
+# PyCharm project settings
+.idea
+.DS_store
+
 # Rope project settings
 .ropeproject
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to core_tools will be documented in this file.
 
+## will be \[1.5.1]
+- Fixed bug where `QTextEdit` type hint was called in `core_tools.GUI.keysight_videomaps.GUI.favorites` 
+
 ## \[1.5.0] - 2024-10-07
 
 - "Official" release of new Video Mode.

--- a/core_tools/GUI/keysight_videomaps/GUI/favorites.py
+++ b/core_tools/GUI/keysight_videomaps/GUI/favorites.py
@@ -115,7 +115,7 @@ class Favorites:
                 raise
         return settings
 
-    def _parse_settings_text(self, text_edit: QtWidgets.QTextEdit(), group: str):
+    def _parse_settings_text(self, text_edit: QtWidgets.QTextEdit, group: str):
         text = text_edit.toPlainText()
         if text == "":
             return {}


### PR DESCRIPTION
This fixes the crash that occurs when importing `core_tools.GUI.keysight_videomaps.GUI.favorites`.
- Removed parentheses from QTextEdit type hint

I hope this PR is of use, Sander.
