### PR TITLE
hack to enable sqlite as backend

### DIFF
--- a/core_tools/data/SQL/SQL_common_commands.py
+++ b/core_tools/data/SQL/SQL_common_commands.py
@@ -1,30 +1,149 @@
+import sqlite3
+import psycopg2
 from psycopg2.extras import RealDictCursor
 from psycopg2 import sql
 
-from core_tools.data.SQL.SQL_utility import sql_name_formatter, sql_value_formatter, name_value_formatter
+from core_tools.data.SQL.SQL_utility import (
+    sql_name_formatter,
+    sql_value_formatter,
+    name_value_formatter,
+)
 
-def execute_statement(conn, statement, placeholders = []):
+
+class sqlite_helper:
+    @staticmethod
+    def quote_ident(identifier):
+        for character in identifier:
+            if character == "\0" or character > "\x7f":
+                raise ValueError(
+                    "SQLite identifier cannot contain NUL or non-ASCII character."
+                )
+
+        return '"' + identifier.replace('"', '""') + '"'
+
+    @classmethod
+    def ident_as_string(cls, ident: sql.Identifier) -> str:
+        return ".".join(cls.quote_ident(s) for s in ident._wrapped)
+
+    @classmethod
+    def literal_as_string(cls, literal: sql.Literal) -> str:
+        val = literal._wrapped
+        if isinstance(val, int | float):
+            return str(val)
+        if isinstance(val, str):
+            return cls.quote_ident(val)
+
+        return literal.as_string(None)
+
+    @classmethod
+    def composed_as_string(cls, composed: sql.Composed) -> str:
+        rv = []
+        for item in composed._wrapped:
+            match item:
+                case sql.Composed():
+                    rv.append(cls.composed_as_string(item))
+                case sql.Identifier():
+                    rv.append(cls.ident_as_string(item))
+                case sql.Literal():
+                    rv.append(cls.literal_as_string(item))
+                case _:
+                    rv.append(item.as_string(None))
+        return "".join(rv)
+
+    @classmethod
+    def is_active(cls, cursor):
+        return isinstance(cursor, sqlite3.Cursor)
+
+    @classmethod
+    def convert_to_string(cls, statement):
+        if isinstance(statement, sql.Composed):
+            return cls.composed_as_string(statement)
+        return statement
+
+    @classmethod
+    def convert_placeholders(cls, placeholders):
+        # return placeholders
+        return [cls.convert_one_placeholder(p) for p in placeholders]
+
+    @classmethod
+    def convert_one_placeholder(cls, placeholder):
+        if isinstance(placeholder, psycopg2.Binary):
+            return bytes(placeholder.adapted)
+        return placeholder
+
+    @classmethod
+    def split_multiple_statements(cls, statement, placeholders):
+        s = statement.replace("%s", "?")
+        ls: list[str] = [ss for ss in s.split(";") if ss.strip()]
+        if len(ls) == 0:
+            yield "", cls.convert_placeholders(placeholders)
+        elif len(ls) == 1:
+            yield ls[0], cls.convert_placeholders(placeholders)
+        else:
+            placeholders = placeholders[:]
+            for s in ls:
+                n = s.count("?")
+                yield s, cls.convert_placeholders(placeholders[:n])
+                placeholders = placeholders[n:]
+
+
+def execute_statement(conn, statement, placeholders=[], close_on_error=True):
     try:
         cursor = conn.cursor()
-        cursor.execute(statement, placeholders)
-        cursor.close()
-        return ((), )
+        if sqlite_helper.is_active(cursor):
+            _orig_statement = statement
+            statement = sqlite_helper.convert_to_string(statement)
+            for statement, placeholders in sqlite_helper.split_multiple_statements(
+                statement, placeholders
+            ):
+                cursor.execute(statement, placeholders)
+        else:
+            cursor.execute(statement, placeholders)
+            cursor.close()
+        return ((),)
     except:
+        if not close_on_error:
+            return
+        print(f"{statement}")
         # After exception the connection cannot be used anymore.
         # A new connection will automatically be opened for the next command.
         conn.close()
         raise
 
 
-def execute_query(conn, query, dict_cursor=False, placeholders = []):
+def execute_query(conn, query, dict_cursor=False, placeholders=[]):
     try:
-        if dict_cursor == False:
+        restore_orig_row_factory = False
+
+        if dict_cursor is False:
             cursor = conn.cursor()
         else:
-            cursor = conn.cursor(cursor_factory=RealDictCursor)
+            if not isinstance(conn, sqlite3.Connection):
+                cursor = conn.cursor(cursor_factory=RealDictCursor)
+            else:
+                if dict_cursor is not False:
+                    def dict_factory(cursor, row):
+                        d = {}
+                        for idx, col in enumerate(cursor.description):
+                            d[col[0]] = row[idx]
+                        return d
 
-        cursor.execute(query, placeholders)
-        return_values = cursor.fetchall()
+                    restore_orig_row_factory = True
+                    orig_row_factory = conn.row_factory
+                    conn.row_factory = dict_factory
+
+                cursor = conn.cursor()
+
+        if sqlite_helper.is_active(cursor):
+            query = sqlite_helper.convert_to_string(query)
+
+        try:
+            cursor.execute(query, placeholders)
+            return_values = cursor.fetchall()
+        finally:
+            if restore_orig_row_factory:
+                conn.row_factory = orig_row_factory
+
         cursor.close()
         return return_values
     except:
@@ -34,8 +153,10 @@ def execute_query(conn, query, dict_cursor=False, placeholders = []):
         raise
 
 
-def select_elements_in_table(conn, table_name, var_names, where=None, order_by = None, limit=None, dict_cursor=True):
-    '''
+def select_elements_in_table(
+    conn, table_name, var_names, where=None, order_by=None, limit=None, dict_cursor=True
+):
+    """
     execute a query on a table
 
     Args:
@@ -46,25 +167,32 @@ def select_elements_in_table(conn, table_name, var_names, where=None, order_by =
         order_by (tuple, str) : order results (e.g. ('uuid',  'DESC')
         limit (int) : limit the amount of results
         dict_cursor (bool) : return result as an ordered dict
-    '''
+    """
     var_names_SQL = sql_name_formatter(var_names)
 
     query = sql.SQL("select {0} from {1} ").format(
-                sql.SQL(', ').join(var_names_SQL),
-                sql.SQL(table_name))
+        sql.SQL(", ").join(var_names_SQL), sql.SQL(table_name)
+    )
     # SQL.Identifier does not work with underscore names for tables?
 
     if where is not None:
-        query += sql.SQL("WHERE {0} = {1} ").format(sql.Identifier(where[0]), sql.Literal(where[1]))
+        query += sql.SQL("WHERE {0} = {1} ").format(
+            sql.Identifier(where[0]), sql.Literal(where[1])
+        )
     if order_by is not None:
-        query += sql.SQL("ORDER BY {0} {1} ").format(sql.Identifier(order_by[0]), sql.SQL(order_by[1]))
+        query += sql.SQL("ORDER BY {0} {1} ").format(
+            sql.Identifier(order_by[0]), sql.SQL(order_by[1])
+        )
     if limit is not None:
         query += sql.SQL("LIMIT {0} ").format(sql.SQL(str(int(limit))))
 
     return execute_query(conn, query, dict_cursor)
 
-def insert_row_in_table(conn, table_name, var_names, var_values, returning=None, custom_statement=''):
-    '''
+
+def insert_row_in_table(
+    conn, table_name, var_names, var_values, returning=None, custom_statement=""
+):
+    """
     insert a row in a table
 
     Args:
@@ -73,24 +201,33 @@ def insert_row_in_table(conn, table_name, var_names, var_values, returning=None,
         var_names (tuple<str>) : variable names of the table
         var_values (tuple<str>) : values corresponding to the variable names
         returning (tuple<str>) : name of a variables you want returned
-    '''
+    """
     var_values_SQL, placeholders = sql_value_formatter(var_values)
     var_names_SQL = sql_name_formatter(var_names)
 
-    statement = sql.SQL("INSERT INTO {} ({}) VALUES ({}) ").format(sql.SQL(table_name),
-            sql.SQL(', ').join(var_names_SQL),
-            sql.SQL(', ').join(var_values_SQL))
+    statement = sql.SQL("INSERT INTO {} ({}) VALUES ({}) ").format(
+        sql.SQL(table_name),
+        sql.SQL(", ").join(var_names_SQL),
+        sql.SQL(", ").join(var_values_SQL),
+    )
 
     if returning is None:
-        return execute_statement(conn, statement + sql.SQL(custom_statement), placeholders)
+        return execute_statement(
+            conn, statement + sql.SQL(custom_statement), placeholders
+        )
     else:
-        statement += sql.SQL(" RETURNING {} ").format(sql.SQL(", ").join([sql.Identifier(i) for i in returning]))
-        return execute_query(conn, statement + sql.SQL(custom_statement), placeholders=placeholders)
+        statement += sql.SQL(" RETURNING {} ").format(
+            sql.SQL(", ").join([sql.Identifier(i) for i in returning])
+        )
+        return execute_query(
+            conn, statement + sql.SQL(custom_statement), placeholders=placeholders
+        )
 
 
-def update_table(conn, table_name, var_names, var_values, condition=None,
-                 conditions=None):
-    '''
+def update_table(
+    conn, table_name, var_names, var_values, condition=None, conditions=None
+):
+    """
     generate statement for updating an existing stable
 
     Args:
@@ -100,7 +237,7 @@ def update_table(conn, table_name, var_names, var_values, condition=None,
         var_values (tuple<str>) : values corresponding to the variable names
         condition (tuple<str, any>) : condition for the update (e.g. ('id', 5))
         conditions (list(tuple<str, any>)) : conditiosn for the update (e.g. [('id', 5), ('version', 10)] )
-    '''
+    """
 
     statement = sql.SQL("UPDATE {} SET ").format(sql.SQL(table_name))
 
@@ -108,21 +245,30 @@ def update_table(conn, table_name, var_names, var_values, condition=None,
     if len(names_values) == 0:
         return ""
 
-    statement += sql.SQL(', ').join(sql.SQL("{} = {} ").format(i,j) for i,j in names_values.var_name_pairs)
+    statement += sql.SQL(", ").join(
+        sql.SQL("{} = {} ").format(i, j) for i, j in names_values.var_name_pairs
+    )
 
     if condition is not None:
-        statement += sql.SQL("WHERE {0} = {1} ").format(sql.Identifier(condition[0]), sql.Literal(condition[1]))
+        statement += sql.SQL("WHERE {0} = {1} ").format(
+            sql.Identifier(condition[0]), sql.Literal(condition[1])
+        )
 
     if conditions is not None and len(conditions) > 0:
         condition = conditions[0]
-        statement += sql.SQL("WHERE {0} = {1} ").format(sql.Identifier(condition[0]), sql.Literal(condition[1]))
+        statement += sql.SQL("WHERE {0} = {1} ").format(
+            sql.Identifier(condition[0]), sql.Literal(condition[1])
+        )
         for condition in conditions[1:]:
-            statement += sql.SQL("AND {0} = {1} ").format(sql.Identifier(condition[0]), sql.Literal(condition[1]))
+            statement += sql.SQL("AND {0} = {1} ").format(
+                sql.Identifier(condition[0]), sql.Literal(condition[1])
+            )
 
     return execute_statement(conn, statement, placeholders=names_values.placeholders)
 
+
 def alter_table(conn, table_name, colums, dtypes):
-    '''
+    """
     add columns to a table
 
     Args:
@@ -130,8 +276,11 @@ def alter_table(conn, table_name, colums, dtypes):
         table_name (str) : name of the table to update
         colums (tuple<str>) : names of the columns
         dtypes (tuple<str>) : type of the column's
-    '''
+    """
     statement = sql.SQL("ALTER TABLE {} ADD COLUMN ").format(sql.SQL(table_name))
-    statement += sql.SQL(" , ADD COLUMN ").join(sql.SQL(" {0} {1} ").format(sql.Identifier(i), sql.SQL(j)) for i, j in zip(colums, dtypes))
+    statement += sql.SQL(" , ADD COLUMN ").join(
+        sql.SQL(" {0} {1} ").format(sql.Identifier(i), sql.SQL(j))
+        for i, j in zip(colums, dtypes)
+    )
 
     return execute_statement(conn, statement)

--- a/core_tools/data/SQL/connect.py
+++ b/core_tools/data/SQL/connect.py
@@ -69,17 +69,19 @@ class SQL_conn_info_local:
     passwd = conn_info_descriptor()
     dbname = conn_info_descriptor()
     readonly = conn_info_descriptor()
+    is_sqlite = conn_info_descriptor()
 
-    def __init__(self, host, port, user, passwd, dbname, readonly=False):
+    def __init__(self, host, port, user, passwd, dbname, readonly=False, is_sqlite=False):
         self.host = host
         self.port = port
         self.user = user
         self.passwd = passwd
         self.dbname = dbname
         self.readonly = readonly
+        self.is_sqlite=is_sqlite
 
     def __repr__(self):
-        return f'{self.__class__}: host {self.host}, port {self.port}, user {self.user}, passwd *, dbname {self.dbname}, readonly {self.readonly}'
+        return f'{self.__class__}: host {self.host}, port {self.port}, user {self.user}, passwd *, dbname {self.dbname}, readonly {self.readonly}, is_sqlite {self.is_sqlite}'
 
 class SQL_conn_info_remote:
     host = conn_info_descriptor()
@@ -88,19 +90,21 @@ class SQL_conn_info_remote:
     passwd = conn_info_descriptor()
     dbname = conn_info_descriptor()
     readonly = conn_info_descriptor()
+    is_sqlite = conn_info_descriptor()
 
-    def __init__(self, host, port, user, passwd, dbname, readonly=False):
+    def __init__(self, host, port, user, passwd, dbname, readonly=False, is_sqlite=False):
         self.host = host
         self.port = port
         self.user = user
         self.passwd = passwd
         self.dbname = dbname
         self.readonly = readonly
+        self.is_sqlite = is_sqlite
 
     def __repr__(self):
-        return f'{self.__class__}: host {self.host}, port {self.port}, user {self.user}, passwd *, dbname {self.dbname}, readonly {self.readonly}'
+        return f'{self.__class__}: host {self.host}, port {self.port}, user {self.user}, passwd *, dbname {self.dbname}, readonly {self.readonly}, is_sqlite {self.is_sqlite}'
 
-def set_up_local_storage(user, passwd, dbname, project, set_up, sample, readonly=False):
+def set_up_local_storage(user, passwd, dbname, project, set_up, sample, readonly=False, is_sqlite=False):
     '''
     Set up the specification for the datastorage needed to store/retrieve measurements.
 
@@ -113,7 +117,7 @@ def set_up_local_storage(user, passwd, dbname, project, set_up, sample, readonly
         set_up (str) : set up at which the data has been measured
         sample (str) : sample name
     '''
-    SQL_conn_info_local('localhost', 5432, user, passwd, dbname, readonly)
+    SQL_conn_info_local('localhost', 5432, user, passwd, dbname, readonly, is_sqlite)
     sample_info(project, set_up, sample)
 
 def set_up_remote_storage(host, port, user, passwd, dbname, project, set_up, sample, readonly=False):


### PR DESCRIPTION
This is a hack to allow using Sqlite3 as local database backend in the Core-tools.
It has only been tested to work with the Video Mode and the storage for the Virtual Gate Matrix.

It is not a generic solution but can be used as a basis for a generic solution.